### PR TITLE
fix: supply type parameter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ interface NotebookEntryProps {
   value: NotebookEntryProp
 }
 
-class NotebookEntry extends React.Component {
+class NotebookEntry extends React.Component<NotebookEntryProps> {
   state: NotebookEntryState
 
   constructor(props: NotebookEntryProps) {


### PR DESCRIPTION
This PR supplies the `NotebookEntryProps` type as the `props` type parameter to `NotebookEntry`.  It's this that lets `NotebookEntry` know that it is connected to `NotebookEntryProps`.  You should now be able to compile!